### PR TITLE
Remove immutable sequence generation

### DIFF
--- a/src/kat_transform/field.py
+++ b/src/kat_transform/field.py
@@ -1,7 +1,7 @@
 import typing
 import collections.abc
 from functools import cache
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 from .util import get_by_name
@@ -38,43 +38,6 @@ class FieldSpec(typing.Generic[I, O]):
     """
     Define metadata for this field
     """
-
-    @property
-    @cache
-    def _origin(self):
-        return typing.get_origin(self.output_type)
-
-    @property
-    @cache
-    def is_typed_mutable_sequence(self):
-        if self._origin is None:
-            return False
-
-        return issubclass(self._origin, collections.abc.MutableSequence)
-
-    @property
-    @cache
-    def is_typed_sequence(self):
-        if self._origin is None:
-            return False
-
-        return issubclass(self._origin, collections.abc.Sequence)
-
-    @property
-    @cache
-    def is_typed_mapping(self):
-        if self._origin is None:
-            return False
-
-        return issubclass(self._origin, collections.abc.Mapping)
-
-    @property
-    @cache
-    def item_type(self):
-        if self.is_typed_sequence:
-            return typing.get_args(self.output_type)[0]
-        elif self.is_typed_mapping:
-            return typing.get_args(self.output_type)[1]
 
     def get(self, from_: typing.Any) -> I | O | ValueGetter:
         """

--- a/src/kat_transform/util.py
+++ b/src/kat_transform/util.py
@@ -1,3 +1,4 @@
+from functools import cache
 import typing
 import collections.abc
 
@@ -18,3 +19,25 @@ def get_by_name(name: str, from_: typing.Any) -> typing.Any:
     assert hasattr(from_, name), f'{from_!r} has no attribute "{name}"'
 
     return getattr(from_, name)
+
+
+@cache
+def is_typed_sequence(annotation: typing.Any) -> bool:
+    origin = typing.get_origin(annotation)
+    return origin and issubclass(origin, collections.abc.Sequence)
+
+
+@cache
+def is_typed_mapping(annotation: typing.Any) -> bool:
+    origin = typing.get_origin(annotation)
+    return origin and issubclass(origin, collections.abc.Mapping)
+
+
+@cache
+def get_item_type(annotation: typing.Any) -> typing.Any:
+    args = typing.get_args(annotation)
+    if is_typed_sequence(annotation):
+        return args[0]
+
+    if is_typed_mapping(annotation):
+        return args[1]

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -37,18 +37,6 @@ def test_transform_subschema_in_mutable_sequence():
     assert transformed == {"sub": [{"name": "NAME"}]}
 
 
-def test_transform_subschema_in_immutable_sequence():
-    sub = schema("Sub", field(str, "name", transform=lambda x: x.upper()))
-
-    spec = schema("Schema", field(tuple[sub], "sub"))
-
-    raw = spec.get({"sub": [{"name": "name"}]})
-
-    transformed = transform(raw)
-
-    assert transformed == {"sub": ({"name": "NAME"},)}
-
-
 def test_transform_subschema_in_mapping():
     sub = schema("Sub", field(str, "name", transform=lambda x: x.upper()))
 


### PR DESCRIPTION
Library that specifies on data transformation to prepare it for serialization does not have to worry about mutable or immutable data types.

This change makes that any `field(Sequence[schema], name)` would transform into mutable list.